### PR TITLE
Created an alias to specify functions that use return codes

### DIFF
--- a/src/core/tictactics_board.h
+++ b/src/core/tictactics_board.h
@@ -5,6 +5,8 @@
 #include <tictactics_player.h>
 #include <string>
 
+typedef int RetCode;
+
 class Board {
     public:
         Board();
@@ -13,9 +15,9 @@ class Board {
         int width();
         int height();
 
-        int resetBoard();
-        int printBoard();
-        int updateBoard(Player player, int move_idx);
+        RetCode resetBoard();
+        RetCode printBoard();
+        RetCode updateBoard(Player player, int move_idx);
 
         int  getPlayerMove(Player player);
         bool isMoveValid(const std::string& user_input);

--- a/src/core/tictactics_gameplay.h
+++ b/src/core/tictactics_gameplay.h
@@ -6,6 +6,8 @@
 #include <tictactics_player.h>
 #include <vector>
 
+typedef int RetCode;
+
 class Game {
     public:
         Game();
@@ -13,8 +15,8 @@ class Game {
         std::vector<Player> Players();
         Board               getBoard();
 
-        int addPlayer(Player player);
-        int play();
+        RetCode addPlayer(Player player);
+        RetCode play();
         
     private:
         std::vector<Player> d_Players;

--- a/tests/unit/core/smoke_test.t.cpp
+++ b/tests/unit/core/smoke_test.t.cpp
@@ -1,9 +1,0 @@
-#include <gtest/gtest.h>
-
-namespace {
-    int getMeaningOfLife() { return 42; }
-}
-
-TEST(SmokeTest, SimpleAssertion) {
-    ASSERT_EQ(42, getMeaningOfLife());
-}

--- a/tests/unit/core/tictactics_board.t.cpp
+++ b/tests/unit/core/tictactics_board.t.cpp
@@ -34,7 +34,7 @@ TEST(TictacticsBoard, ResetBoardReturnsSuccess) {
     Board TBoard;
 
     // When
-    const int rcode = TBoard.resetBoard();
+    const RetCode rcode = TBoard.resetBoard();
 
     // Then
     ASSERT_EQ(0, rcode);
@@ -46,7 +46,7 @@ TEST(TictacticsBoard, PrintBoardReturnsSuccess) {
 
     // When
     ::testing::internal::CaptureStdout(); // Captures cout text
-    const int rcode = TBoard.printBoard();
+    const RetCode rcode = TBoard.printBoard();
     ::testing::internal::GetCapturedStdout();
 
     // Then


### PR DESCRIPTION
## Problem
`int` functions that use return codes are harder to identify from `int` functions that return more consequential values

## Solution
Make a separate `ReturnCode` type for functions that return the (enum) integer return code.